### PR TITLE
Enhance solar light simulator with typical defaults

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -22,7 +22,7 @@
       padding: 8px;
       font-size: 1em;
     }
-    button {
+  button {
       margin-top: 1em;
       padding: 10px;
       background: #007bff;
@@ -30,6 +30,10 @@
       border: none;
       border-radius: 4px;
       cursor: pointer;
+    }
+    .note {
+      color: #666;
+      font-size: 0.9em;
     }
     canvas {
       margin-top: 30px;
@@ -42,21 +46,30 @@
 
 <label for="capacity">Battery Capacity (mAh)</label>
 <input type="number" id="capacity" value="1000">
+<small class="note">Typical AA/AAA NiMH: 600–1000 mAh</small>
 
 <label for="soc">Initial SoC (%)</label>
 <input type="number" id="soc" value="100" min="0" max="100">
+<small class="note">Usually 80–100% after full charge</small>
 
 <label for="cells">NiCd Cell Count</label>
 <input type="number" id="cells" value="1">
+<small class="note">Most garden lights use 1 cell</small>
 
 <label for="sunHours">Direct Sunlight Hours</label>
 <input type="number" id="sunHours" value="3">
+<small class="note">Commonly 3–6 hours</small>
 
 <label for="nightHours">Night Illumination Hours</label>
 <input type="number" id="nightHours" value="9">
+<small class="note">Usually 8–12 hours</small>
 
 <label for="ledCurrent">LED Nominal Current @ 1.2V (mA)</label>
-<input type="number" id="ledCurrent" value="30">
+<input type="number" id="ledCurrent" value="20">
+<small class="note">Typical white LED current: ≈20 mA</small>
+<label for="driverEff">LED Driver Efficiency (%)</label>
+<input type="number" id="driverEff" value="80" min="0" max="100">
+<small class="note">Joule thief/boost driver: 70–85%</small>
 
 <label for="days">Days to Simulate</label>
 <input type="number" id="days" value="10" min="1">
@@ -95,6 +108,7 @@ function simulate() {
   const sunHours = parseInt(document.getElementById("sunHours").value);
   const nightHours = parseInt(document.getElementById("nightHours").value);
   const ledNominalCurrent = parseFloat(document.getElementById("ledCurrent").value);
+  const driverEff = parseFloat(document.getElementById("driverEff").value) / 100;
   const days = parseInt(document.getElementById("days").value);
   const voc = parseFloat(document.getElementById("voc").value);
   const isc = parseFloat(document.getElementById("isc").value);
@@ -145,7 +159,7 @@ function simulate() {
         }
       } else if (isNight) {
         // Adjust LED current to maintain constant power
-        const actualLEDCurrent = batteryV > 0 ? ledPower_mW / batteryV : 0;
+        const actualLEDCurrent = batteryV > 0 ? (ledPower_mW / driverEff) / batteryV : 0;
         delta_mAh = -actualLEDCurrent; // 1 hour
       }
 


### PR DESCRIPTION
## Summary
- tweak defaults for a common garden light and show helpful notes
- add input for LED driver efficiency
- calculate LED current using driver efficiency
- include styling for note text

## Testing
- `tidy -errors -q calc.html`

------
https://chatgpt.com/codex/tasks/task_e_6851f4802004832a87470869cc79f935