### PR TITLE
Update default values for pessimistic scenario

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -45,11 +45,11 @@
 <h1>Realistic Solar Battery Simulation</h1>
 
 <label for="capacity">Battery Capacity (mAh)</label>
-<input type="number" id="capacity" value="1000">
+<input type="number" id="capacity" value="600">
 <small class="note">Typical AA/AAA NiMH: 600–1000 mAh</small>
 
 <label for="soc">Initial SoC (%)</label>
-<input type="number" id="soc" value="100" min="0" max="100">
+<input type="number" id="soc" value="80" min="0" max="100">
 <small class="note">Usually 80–100% after full charge</small>
 
 <label for="cells">Cell Count</label>
@@ -58,24 +58,24 @@
 
 <label for="chemistry">Battery Chemistry</label>
 <select id="chemistry">
-  <option value="NiMH" selected>NiMH</option>
-  <option value="NiCad">NiCad</option>
+  <option value="NiMH">NiMH</option>
+  <option value="NiCad" selected>NiCad</option>
 </select>
 <small class="note">Affects safe discharge voltage</small>
 
 <label for="sunHours">Direct Sunlight Hours</label>
-<input type="number" id="sunHours" value="3">
+<input type="number" id="sunHours" value="2">
 <small class="note">Commonly 3–6 hours</small>
 
 <label for="nightHours">Night Illumination Hours</label>
-<input type="number" id="nightHours" value="9">
+<input type="number" id="nightHours" value="12">
 <small class="note">Usually 8–12 hours</small>
 
 <label for="ledCurrent">LED Nominal Current @ 1.2V (mA)</label>
-<input type="number" id="ledCurrent" value="20">
+<input type="number" id="ledCurrent" value="30">
 <small class="note">Typical white LED current: ≈20 mA</small>
 <label for="driverEff">LED Driver Efficiency (%)</label>
-<input type="number" id="driverEff" value="80" min="0" max="100">
+<input type="number" id="driverEff" value="70" min="0" max="100">
 <small class="note">Joule thief/boost driver: 70–85%</small>
 
 <label for="days">Days to Simulate</label>
@@ -84,22 +84,22 @@
 <h3>Solar Cell</h3>
 <!-- Defaults tuned for an uxcell 1.5V 150mA panel with a Schottky diode -->
 <label for="voc">Open-Circuit Voltage (Voc) [V]</label>
-<input type="number" id="voc" value="2.2" step="any">
+<input type="number" id="voc" value="2.0" step="any">
 
 <label for="isc">Short-Circuit Current (Isc) [mA]</label>
-<input type="number" id="isc" value="150">
+<input type="number" id="isc" value="100">
 
 <label for="ff">Fill Factor (FF, 0–1)</label>
-<input type="number" id="ff" value="0.75" step="any">
+<input type="number" id="ff" value="0.65" step="any">
 
 <label for="diodeDrop">Diode Voltage Drop (V)</label>
-<input type="number" id="diodeDrop" value="0.25" step="any">
+<input type="number" id="diodeDrop" value="0.4" step="any">
 
 <label for="chargeEff">Charge Efficiency (%)</label>
-<input type="number" id="chargeEff" value="85" min="0" max="100">
+<input type="number" id="chargeEff" value="70" min="0" max="100">
 
 <label for="selfDischarge">Self-Discharge Rate (%/day)</label>
-<input type="number" id="selfDischarge" value="1" min="0" step="any">
+<input type="number" id="selfDischarge" value="3" min="0" step="any">
 
 <button onclick="simulate()">Simulate</button>
 


### PR DESCRIPTION
## Summary
- use pessimistic defaults for a cheap solar light setup

## Testing
- `git diff --stat`

------
https://chatgpt.com/codex/tasks/task_e_6851f69bb130832a91c80b4aa797a7c9