### PR TITLE
Make chart full-width at top of page

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -36,13 +36,18 @@
       font-size: 0.9em;
     }
     canvas {
-      margin-top: 30px;
+      display: block;
+      width: 100%;
+      height: 400px;
+      margin-bottom: 30px;
     }
   </style>
 </head>
 <body>
 
 <h1>Realistic Solar Battery Simulation</h1>
+
+<canvas id="chart"></canvas>
 
 <label for="capacity">Battery Capacity (mAh)</label>
 <input type="number" id="capacity" value="600">
@@ -122,7 +127,6 @@
 
 <button onclick="simulate()">Simulate</button>
 
-<canvas id="chart" width="700" height="400"></canvas>
 
 <script>
 let chart;


### PR DESCRIPTION
## Summary
- move the canvas to the top of the page below the heading
- style the canvas so it spans the full container width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851fb388964832a82fc64e86a7d890b