### PR TITLE
Add color-coded sunlight and LED states

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -72,6 +72,10 @@
 <input type="number" id="sunHours" value="4">
 <small class="note">Commonly 3–6 hours</small>
 
+<label for="morningHours">Indirect Morning Light Hours</label>
+<input type="number" id="morningHours" value="1" min="0">
+<small class="note">Early dawn ambient light</small>
+
 <label for="nightHours">Night Illumination Hours</label>
 <input type="number" id="nightHours" value="8">
 <small class="note">Usually 8–12 hours</small>
@@ -136,6 +140,7 @@ function simulate() {
   const initialSoC = parseFloat(document.getElementById("soc").value);
   const cells = parseInt(document.getElementById("cells").value);
   const sunHours = parseInt(document.getElementById("sunHours").value);
+  const morningHours = parseInt(document.getElementById("morningHours").value);
   const nightHours = parseInt(document.getElementById("nightHours").value);
   const sunrise = parseInt(document.getElementById("sunrise").value);
   const sunset = parseInt(document.getElementById("sunset").value);
@@ -163,7 +168,15 @@ function simulate() {
   const socColors = [];
   const voltageData = [];
   const ledData = [];
+  const sunData = [];
+  const dayData = [];
+  const morningData = [];
   const labels = [];
+  // Non-direct light factors based on typical cloudy-day output
+  // Solar panels produce around 10–25% of normal power when clouds block the sun
+  // See: duckduckgo result snippet mentioning 10–25% output on cloudy days
+  const dayFactor = 0.2; // daylight but not direct sun
+  const morningFactor = 0.05; // very low early morning light
 
   // LED power at 1.2V baseline
   const ledPower_mW = 1.2 * ledNominalCurrent;
@@ -192,32 +205,52 @@ function simulate() {
       socColors.push(soc > 80 ? 'gold' : soc < 30 ? 'red' : '#28a745');
 
       let delta_mAh = 0;
-      const isSun = hour >= sunrise && hour < Math.min(24, sunrise + sunHours);
+      const directSunEnd = Math.min(sunset, sunrise + sunHours);
+      const isSun = hour >= sunrise && hour < directSunEnd;
+      const isDay = hour >= sunrise && hour < sunset;
+      const morningStart = sunrise - morningHours;
+      const isMorning = morningHours > 0 && (morningStart >= 0
+        ? (hour >= morningStart && hour < sunrise)
+        : (hour >= morningStart + 24 || hour < sunrise));
       const nightEnd = (sunset + nightHours) % 24;
       const isNight = nightEnd > sunset ?
         (hour >= sunset && hour < nightEnd) :
         (hour >= sunset || hour < nightEnd);
 
+      sunData.push(isSun ? 1 : 0);
+      dayData.push(isDay && !isSun ? 1 : 0);
+      morningData.push(isMorning ? 1 : 0);
+
       const ledOn = isNight && batteryV > cells * boostCutoff;
       ledData.push(ledOn ? 1 : 0);
 
-      if (isSun) {
-        const vLoad = batteryV + diodeDrop;
-        if (vLoad < voc) {
-          const pMax = voc * isc * ff; // mW
-          const vmpp = voc * 0.8; // approximate voltage at MPP
-          const impp = pMax / vmpp; // current at MPP
-          let solarCurrent;
-          if (vLoad <= vmpp) {
-            // operate near MPP for lower battery voltage
-            solarCurrent = pMax / vLoad;
-          } else {
-            // linear drop of current above MPP toward Voc
-            solarCurrent = impp * (1 - (vLoad - vmpp) / (voc - vmpp));
-          }
-          solarCurrent = Math.max(0, Math.min(isc, solarCurrent));
+      if (isSun || isDay || isMorning) {
+        let intensity = 0;
+        if (isSun) {
+          intensity = 1;
+        } else if (isDay) {
+          intensity = dayFactor;
+        }
+        if (isMorning) intensity = Math.max(intensity, morningFactor);
 
-          delta_mAh = solarCurrent * chargeEff; // 1 hour
+        if (intensity > 0) {
+          const vLoad = batteryV + diodeDrop;
+          if (vLoad < voc) {
+            const pMax = voc * isc * ff * intensity; // mW scaled by light level
+            const vmpp = voc * 0.8; // approximate voltage at MPP
+            const impp = pMax / vmpp; // current at MPP
+            let solarCurrent;
+            if (vLoad <= vmpp) {
+              // operate near MPP for lower battery voltage
+              solarCurrent = pMax / vLoad;
+            } else {
+              // linear drop of current above MPP toward Voc
+              solarCurrent = impp * (1 - (vLoad - vmpp) / (voc - vmpp));
+            }
+            solarCurrent = Math.max(0, Math.min(isc * intensity, solarCurrent));
+
+            delta_mAh = solarCurrent * chargeEff; // 1 hour
+          }
         }
       } else if (ledOn) {
         // Adjust LED current to maintain constant power
@@ -281,9 +314,33 @@ function simulate() {
         },
         {
           type: 'bar',
+          label: 'Direct Sun',
+          data: sunData,
+          backgroundColor: 'rgba(255,255,0,0.3)',
+          borderWidth: 0,
+          yAxisID: 'yLED'
+        },
+        {
+          type: 'bar',
+          label: 'Morning Light',
+          data: morningData,
+          backgroundColor: 'rgba(173,216,230,0.3)',
+          borderWidth: 0,
+          yAxisID: 'yLED'
+        },
+        {
+          type: 'bar',
+          label: 'Daylight',
+          data: dayData,
+          backgroundColor: 'rgba(255,165,0,0.3)',
+          borderWidth: 0,
+          yAxisID: 'yLED'
+        },
+        {
+          type: 'bar',
           label: 'LED On',
           data: ledData,
-          backgroundColor: 'rgba(255,215,0,0.3)',
+          backgroundColor: 'rgba(0,255,255,0.3)',
           borderWidth: 0,
           yAxisID: 'yLED'
         }


### PR DESCRIPTION
## Summary
- visualize direct sunlight and daylight with new color bars
- switch LED indicator color to cyan
- include indirect morning light tracking
- simulate power generation during indirect daylight and early morning based on a 20% cloudy-day factor

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6852053e3798832ab2502c7c12733001