### PR TITLE
Add indirect sunlight power generation

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -72,6 +72,10 @@
 <input type="number" id="sunHours" value="4">
 <small class="note">Commonly 3–6 hours</small>
 
+<label for="indirectHours">Indirect Sunlight Hours</label>
+<input type="number" id="indirectHours" value="0" min="0">
+<small class="note">Shaded or off-angle sun</small>
+
 <label for="morningHours">Indirect Morning Light Hours</label>
 <input type="number" id="morningHours" value="1" min="0">
 <small class="note">Early dawn ambient light</small>
@@ -140,6 +144,7 @@ function simulate() {
   const initialSoC = parseFloat(document.getElementById("soc").value);
   const cells = parseInt(document.getElementById("cells").value);
   const sunHours = parseInt(document.getElementById("sunHours").value);
+  const indirectHours = parseInt(document.getElementById("indirectHours").value);
   const morningHours = parseInt(document.getElementById("morningHours").value);
   const nightHours = parseInt(document.getElementById("nightHours").value);
   const sunrise = parseInt(document.getElementById("sunrise").value);
@@ -169,6 +174,7 @@ function simulate() {
   const voltageData = [];
   const ledData = [];
   const sunData = [];
+  const indirectData = [];
   const dayData = [];
   const morningData = [];
   const labels = [];
@@ -177,6 +183,7 @@ function simulate() {
   // See: duckduckgo result snippet mentioning 10–25% output on cloudy days
   const dayFactor = 0.2; // daylight but not direct sun
   const morningFactor = 0.05; // very low early morning light
+  const indirectFactor = 0.1; // shaded or indirect sunlight
 
   // LED power at 1.2V baseline
   const ledPower_mW = 1.2 * ledNominalCurrent;
@@ -206,7 +213,9 @@ function simulate() {
 
       let delta_mAh = 0;
       const directSunEnd = Math.min(sunset, sunrise + sunHours);
+      const indirectEnd = Math.min(sunset, directSunEnd + indirectHours);
       const isSun = hour >= sunrise && hour < directSunEnd;
+      const isIndirect = hour >= directSunEnd && hour < indirectEnd;
       const isDay = hour >= sunrise && hour < sunset;
       const morningStart = sunrise - morningHours;
       const isMorning = morningHours > 0 && (morningStart >= 0
@@ -218,16 +227,19 @@ function simulate() {
         (hour >= sunset || hour < nightEnd);
 
       sunData.push(isSun ? 1 : 0);
-      dayData.push(isDay && !isSun ? 1 : 0);
+      indirectData.push(isIndirect ? 1 : 0);
+      dayData.push(isDay && !isSun && !isIndirect ? 1 : 0);
       morningData.push(isMorning ? 1 : 0);
 
       const ledOn = isNight && batteryV > cells * boostCutoff;
       ledData.push(ledOn ? 1 : 0);
 
-      if (isSun || isDay || isMorning) {
+      if (isSun || isIndirect || isDay || isMorning) {
         let intensity = 0;
         if (isSun) {
           intensity = 1;
+        } else if (isIndirect) {
+          intensity = indirectFactor;
         } else if (isDay) {
           intensity = dayFactor;
         }
@@ -317,6 +329,14 @@ function simulate() {
           label: 'Direct Sun',
           data: sunData,
           backgroundColor: 'rgba(255,255,0,0.3)',
+          borderWidth: 0,
+          yAxisID: 'yLED'
+        },
+        {
+          type: 'bar',
+          label: 'Indirect Sun',
+          data: indirectData,
+          backgroundColor: 'rgba(200,200,0,0.3)',
           borderWidth: 0,
           yAxisID: 'yLED'
         },


### PR DESCRIPTION
## Summary
- add UI input for indirect sunlight hours
- track indirect sunlight intensity at 10%
- account for indirect sun in the simulation and chart

## Testing
- `node -e "require('fs').readFileSync('calc.html','utf8');"`

------
https://chatgpt.com/codex/tasks/task_e_68520b49de48832a851ef9db12d1e949