### PR TITLE
Responsive grid layout for form inputs

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -13,14 +13,27 @@
       padding: 2em;
       border-radius: 8px;
     }
-    label, input {
-      display: block;
-      margin-top: 1em;
-      width: 200px;
+        .form-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1em 2em;
+      align-items: start;
     }
-    input {
+    .field label,
+    .field input,
+    .field select,
+    .field .note {
+      display: block;
+      margin-top: 0.5em;
+    }
+    .field input,
+    .field select {
+      width: 100%;
       padding: 8px;
       font-size: 1em;
+    }
+    .full {
+      grid-column: 1 / -1;
     }
   button {
       margin-top: 1em;
@@ -48,92 +61,140 @@
 <h1>Realistic Solar Battery Simulation</h1>
 
 <canvas id="chart"></canvas>
+<div class="form-grid">
 
+<div class="field">
 <label for="capacity">Battery Capacity (mAh)</label>
 <input type="number" id="capacity" value="300">
 <small class="note">Typical AA/AAA NiMH: 300,600 or 1000 mAh</small>
+</div>
 
+<div class="field">
 <label for="soc">Initial SoC (%)</label>
 <input type="number" id="soc" value="70" min="0" max="100">
 <small class="note">Usually 80–100% after full charge</small>
+</div>
 
+<div class="field">
 <label for="cells">Cell Count</label>
 <input type="number" id="cells" value="1" min="1">
 <small class="note">Most garden lights use 1 cell</small>
+</div>
 
+<div class="field">
 <label for="chemistry">Battery Chemistry</label>
 <select id="chemistry">
   <option value="NiMH" selected>NiMH</option>
   <option value="NiCad">NiCad</option>
 </select>
 <small class="note">Affects safe discharge voltage</small>
+</div>
 
+<div class="field">
 <label for="sunHours">Direct Sunlight Hours</label>
 <input type="number" id="sunHours" value="4">
 <small class="note">Commonly 3–6 hours</small>
+</div>
 
+<div class="field">
 <label for="indirectHours">Indirect Sunlight Hours</label>
 <input type="number" id="indirectHours" value="1" min="0">
 <small class="note">Shaded or off-angle sun</small>
+</div>
 
+<div class="field">
 <label for="morningHours">Indirect Morning Light Hours</label>
 <input type="number" id="morningHours" value="1" min="0">
 <small class="note">Early dawn ambient light</small>
+</div>
 
+<div class="field">
 <label for="nightHours">Night Illumination Hours</label>
 <input type="number" id="nightHours" value="8">
 <small class="note">Usually 8–12 hours</small>
+</div>
 
+<div class="field">
 <label for="ledCurrent">LED Nominal Current @ 1.2V (mA)</label>
 <input type="number" id="ledCurrent" value="17">
 <small class="note">Typical white LED current: ≈20 mA</small>
+</div>
+<div class="field">
 <label for="driverEff">LED Driver Efficiency (%)</label>
 <input type="number" id="driverEff" value="70" min="0" max="100">
 <small class="note">Boost driver: 70–85%</small>
+</div>
 
+<div class="field">
 <label for="boostCutoff">Boost Converter Cutoff (V/cell)</label>
 <input type="number" id="boostCutoff" value="0.9" step="any">
 <small class="note">LED driver stops below this voltage</small>
+</div>
 
+<div class="field">
 <label for="sunrise">Sunrise Hour (0–23)</label>
 <input type="number" id="sunrise" value="6" min="0" max="23">
 <small class="note">Average sunrise ~6am</small>
+</div>
 
+<div class="field">
 <label for="sunset">Sunset Hour (0–23)</label>
 <input type="number" id="sunset" value="18" min="1" max="23">
 <small class="note">Average sunset ~6pm</small>
+</div>
 
+<div class="field">
 <label for="days">Days to Simulate</label>
 <input type="number" id="days" value="4" min="1" max="600">
+</div>
 
-<h3>Solar Cell</h3>
+<h3 class="full">Solar Cell</h3>
+<div class="field">
 <label for="voc">Open-Circuit Voltage (Voc) [V]</label>
 <input type="number" id="voc" value="2.0" step="any">
+</div>
 
+<div class="field">
 <label for="isc">Short-Circuit Current (Isc) [mA]</label>
 <input type="number" id="isc" value="150">
+</div>
 
+<div class="field">
 <label for="ff">Fill Factor (FF, 0–1)</label>
 <input type="number" id="ff" value="0.65" step="any">
+</div>
 
+<div class="field">
 <label for="diodeDrop">Diode Voltage Drop (V)</label>
 <input type="number" id="diodeDrop" value="0.4" step="any">
+</div>
 
+<div class="field">
 <label for="chargeEff">Charge Efficiency (%)</label>
 <input type="number" id="chargeEff" value="70" min="0" max="100">
+</div>
 
+<div class="field">
 <label for="selfDischarge">Self-Discharge Rate (%/day)</label>
 <input type="number" id="selfDischarge" value="3" min="0" step="any">
+</div>
 
+<div class="field">
 <label><input type="checkbox" id="enableDeg" checked> Simulate Component Degeneration</label>
+</div>
+<div class="field">
 <label for="degBattery">Battery Capacity Loss per Day (%)</label>
 <input type="number" id="degBattery" value="0.05" step="any">
 <small class="note">Typical NiCad loses ~0.05% per day</small>
+</div>
+<div class="field">
 <label for="degSolar">Solar Cell Power Loss per Day (%) (resin)</label>
 <input type="number" id="degSolar" value="0.1" step="any">
 <small class="note">Panel aging ~0.02% per day</small>
+</div>
 
-<button onclick="simulate()">Simulate</button>
+<button class="full" onclick="simulate()">Simulate</button>
+</div>
 
 
 <script>


### PR DESCRIPTION
## Summary
- add responsive form-grid CSS
- group input fields into `.field` containers
- use CSS grid to allow 1-3 column layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6852119da4c4832a86f05efa82c64f68