### PR TITLE
Add range shading for daily mode lines

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -393,11 +393,11 @@ function runSim(simDays, canvasId, oldChart) {
   if (days > 15) {
     datasets.push(
       { label: 'Battery SoC High (%)', data: socHigh, borderColor: '#28a745', tension: 0.3, yAxisID: 'ySoC', fill: false },
-      { label: 'Battery SoC Low (%)', data: socLow, borderColor: '#28a745', tension: 0.3, yAxisID: 'ySoC', fill: false },
+      { label: 'Battery SoC Low (%)', data: socLow, borderColor: '#28a745', tension: 0.3, yAxisID: 'ySoC', fill: '-1', backgroundColor: 'rgba(40,167,69,0.1)' },
       { label: 'Battery Voltage High (V)', data: voltageHigh, borderColor: '#007bff', tension: 0.3, yAxisID: 'yVoltage', fill: false },
-      { label: 'Battery Voltage Low (V)', data: voltageLow, borderColor: '#007bff', tension: 0.3, yAxisID: 'yVoltage', fill: false },
+      { label: 'Battery Voltage Low (V)', data: voltageLow, borderColor: '#007bff', tension: 0.3, yAxisID: 'yVoltage', fill: '-1', backgroundColor: 'rgba(0,123,255,0.1)' },
       { label: 'Battery Current High (mA)', data: currentHigh, borderColor: 'orange', tension: 0.3, yAxisID: 'yCurrent', fill: false },
-      { label: 'Battery Current Low (mA)', data: currentLow, borderColor: 'orange', tension: 0.3, yAxisID: 'yCurrent', fill: false }
+      { label: 'Battery Current Low (mA)', data: currentLow, borderColor: 'orange', tension: 0.3, yAxisID: 'yCurrent', fill: '-1', backgroundColor: 'rgba(255,165,0,0.1)' }
     );
   } else {
     datasets.push(


### PR DESCRIPTION
## Summary
- visualize the high/low range for SoC, voltage and current

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68521802b27c832a845cc6b7488f3619