### PR TITLE
Fix grid layout for all form sections

### DIFF
--- a/calc.html
+++ b/calc.html
@@ -105,6 +105,7 @@
 <small class="note">Average sunset ~6pm</small>
 </div>
 
+<div class="field">
 <label for="days">Days at max zoom (top chart)</label>
 <input type="number" id="days" value="2" min="1" max="15">
 </div>


### PR DESCRIPTION
## Summary
- ensure the main form grid doesn't close after the Environmental section
- wrap "Days at max zoom" field in `.field` container so all sections share the same multi-column layout

## Testing
- `tidy -q -e calc.html`

------
https://chatgpt.com/codex/tasks/task_e_685242bc3f54832a8595389455c6a15a